### PR TITLE
Should update colors in svg styles

### DIFF
--- a/lib/voltron/svg/tag.rb
+++ b/lib/voltron/svg/tag.rb
@@ -132,6 +132,9 @@ module Voltron
           # Set the color of any path/stroke in the svg
           content.gsub! /fill=\"[^\"]+\"/, "fill=\"#{@options[:color]}\""
           content.gsub! /stroke=\"[^\"]+\"/, "stroke=\"#{@options[:color]}\""
+          
+          content.gsub! /fill:#\h+;/, "fill:#{@options[:color]};"
+          content.gsub! /stroke:#\h+;/, "stroke:#{@options[:color]};"
 
           # Write the new svg file
           File.open(to_svg_path, "w") { |f| f.puts content }


### PR DESCRIPTION
Svgs doesn't necessarily always have the fill attribute on the element. It can be defined in styles sections. This commit adds a gsub to ensure colors in style section are updated.