### PR TITLE
Return fully digested asset when compile=false

### DIFF
--- a/lib/voltron/svg.rb
+++ b/lib/voltron/svg.rb
@@ -11,7 +11,11 @@ module Voltron
       def svg_icon(source, options={})
         tag = Voltron::Svg::Tag.new(source.value, { extension: :svg }.merge(map_options(options)))
 
-        ::Sass::Script::String.new "url(\"#{tag.image_path}\");\nbackground-image: url(\"#{tag.svg_path}\"), linear-gradient(transparent, transparent);\nbackground-size: #{tag.width}px #{tag.height}px"
+        ::Sass::Script::String.new [
+          "#{asset_url(tag.sass_image_name)};",
+          "background-image: #{asset_url(tag.sass_svg_name)}, linear-gradient(transparent, transparent);",
+          "background-size: #{tag.width}px #{tag.height}px"
+        ].join("\n")
       end
 
       def map_options(options={})

--- a/lib/voltron/svg/tag.rb
+++ b/lib/voltron/svg/tag.rb
@@ -39,6 +39,8 @@ module Voltron
       def asset_path(filename)
         if Rails.application.config.assets.digest && Rails.application.config.assets.compile
           filename = Rails.application.assets.find_asset(filename).try(:digest_path) || filename
+        elsif Rails.application.config.assets.digest && !Rails.application.config.assets.compile
+          return ActionController::Base.helpers.asset_path(filename)
         end
 
         File.join(Rails.application.config.assets.prefix, filename)
@@ -132,7 +134,7 @@ module Voltron
           # Set the color of any path/stroke in the svg
           content.gsub! /fill=\"[^\"]+\"/, "fill=\"#{@options[:color]}\""
           content.gsub! /stroke=\"[^\"]+\"/, "stroke=\"#{@options[:color]}\""
-          
+
           content.gsub! /fill:#\h+;/, "fill:#{@options[:color]};"
           content.gsub! /stroke:#\h+;/, "stroke:#{@options[:color]};"
 

--- a/lib/voltron/svg/tag.rb
+++ b/lib/voltron/svg/tag.rb
@@ -27,13 +27,13 @@ module Voltron
         create_png if Voltron.config.svg.buildable?
       end
 
-      def image_path
-        # Get the fallback image path, either using the :fallback option if specified, or use the default generated png
-        asset_path (@options[:fallback] || name(:png, size.to_s.downcase, color.upcase))
+      def sass_svg_name
+        Sass::Script::String.new(name(@options[:extension], color.upcase), :string)
       end
 
-      def svg_path
-        asset_path name(@options[:extension], color.upcase)
+      def sass_image_name
+        # Get the fallback image path, either using the :fallback option if specified, or use the default generated png
+        Sass::Script::String.new((@options[:fallback] || name(:png, size.to_s.downcase, color.upcase)), :string)
       end
 
       def asset_path(filename)


### PR DESCRIPTION
When the Rails.application.config.assets.compile is set to false, like
in a Production environment, we need to be able to get the fully
digested asset name.  Otherwise the svgs aren't available.